### PR TITLE
fix(table): Extract Oracle table PK as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes
 
 ## [UNRELEASE]
 
+- `Fixed` extract composite primary keys for oracle
 - `Fixed` protect columns names in insert statement
 
 ## [1.1.1]

--- a/internal/infra/table/extractor_postgres.go
+++ b/internal/infra/table/extractor_postgres.go
@@ -45,7 +45,7 @@ type PostgresDialect struct {
 func (d PostgresDialect) SQL(schema string) string {
 	SQL := `SELECT kcu.table_schema,
 	kcu.table_name,
-	string_agg(kcu.column_name,', ') AS key_columns
+	string_agg(kcu.column_name,',') AS key_columns
 FROM information_schema.table_constraints tco
 JOIN information_schema.key_column_usage kcu
 ON kcu.constraint_name = tco.constraint_name

--- a/internal/infra/table/sql_extractor.go
+++ b/internal/infra/table/sql_extractor.go
@@ -81,7 +81,7 @@ func (e *SQLExtractor) Extract() ([]table.Table, *table.Error) {
 		table := table.Table{
 
 			Name: tableName,
-			Keys: strings.Split(keyColumns, ", "),
+			Keys: strings.Split(keyColumns, ","),
 		}
 		tables = append(tables, table)
 	}


### PR DESCRIPTION
This pull request change the `table extact` SQL Dialect interface.

In this PR, dialect must return primary keys separated by coma `','` and not coma + space `, `. 