### PR TITLE
feat(pull): filter by scanning all rows

### DIFF
--- a/internal/app/pull/http.go
+++ b/internal/app/pull/http.go
@@ -141,7 +141,7 @@ func HandlerFactory(ingressDescriptor string) func(w http.ResponseWriter, r *htt
 		pullExporter := pullExporterFactory(w)
 		puller := pull.NewPuller(plan, datasource, pullExporter, pull.NoTraceListener{})
 
-		e3 := puller.Pull(start, pull.Filter{Limit: limit, Values: pull.Row{}, Where: where, Distinct: distinct}, startSelect, nil, nil)
+		e3 := puller.Pull(start, pull.Filter{Limit: limit, Values: pull.Row{}, Where: where, Distinct: distinct}, startSelect, nil, nil, nil)
 		if e3 != nil {
 			log.Error().Err(e3).Msg("")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/pull/driver_test.go
+++ b/pkg/pull/driver_test.go
@@ -74,7 +74,7 @@ func RunTest(t *testing.T, test *Test) {
 
 	for _, execution := range test.Executions {
 		collector.Reset()
-		assert.NoError(t, puller.Pull(execution.Start, execution.Filter, execution.Select, nil, nil))
+		assert.NoError(t, puller.Pull(execution.Start, execution.Filter, execution.Select, nil, nil, nil))
 		assert.Len(t, collector.Result, len(execution.Result))
 
 		for i := 0; i < len(execution.Result); i++ {
@@ -94,7 +94,7 @@ func RunBench(b *testing.B, test *Test) {
 
 	for _, execution := range test.Executions {
 		collector.Reset()
-		assert.NoError(b, puller.Pull(execution.Start, execution.Filter, execution.Select, nil, nil))
+		assert.NoError(b, puller.Pull(execution.Start, execution.Filter, execution.Select, nil, nil, nil))
 		assert.Len(b, collector.Result, len(execution.Result))
 	}
 }

--- a/tests/suites/pull/pull_with_file_filters.yml
+++ b/tests/suites/pull/pull_with_file_filters.yml
@@ -38,6 +38,16 @@ testcases:
           - result.systemout ShouldEqual {"active":1,"activebool":true,"address_id":13,"create_date":"2006-02-14T00:00:00Z","customer_id":9,"email":"MARGARET.MOORE@sakilacustomer.org","first_name":"MARGARET","last_name":"MOORE","last_update":"2006-02-15T09:57:20Z","store_id":2}
           - result.systemerr ShouldBeEmpty
 
+  - name: pull one value scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"customer_id":9}' > customer_filter.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldEqual {"active":1,"activebool":true,"address_id":13,"create_date":"2006-02-14T00:00:00Z","customer_id":9,"email":"MARGARET.MOORE@sakilacustomer.org","first_name":"MARGARET","last_name":"MOORE","last_update":"2006-02-15T09:57:20Z","store_id":2}
+          - result.systemerr ShouldBeEmpty
+
   - name: pull error value
     steps:
       - script: sed -i "s/true/false/g" ingress-descriptor.yaml
@@ -47,11 +57,30 @@ testcases:
           - result.code ShouldEqual 1
           - result.systemout ShouldBeEmpty
 
+  - name: pull error value scann mode should not be detected
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"no_column_id":9}' > customer_filter.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldBeEmpty
+
   - name: pull no value
     steps:
       - script: sed -i "s/true/false/g" ingress-descriptor.yaml
       - script: echo '{"customer_id":-1}' > customer_filter.jsonl
       - script: lino pull source --filter-from-file customer_filter.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldBeEmpty
+          - result.systemerr ShouldBeEmpty
+
+  - name: pull no value scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"customer_id":-1}' > customer_filter.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl
         assertions:
           - result.code ShouldEqual 0
           - result.systemout ShouldBeEmpty
@@ -67,6 +96,16 @@ testcases:
           - result.systemout ShouldEqual {"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}
           - result.systemerr ShouldBeEmpty
 
+  - name: pull many value with implicit limit to 1 scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"active":1}' > customer_filter.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldEqual {"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}
+          - result.systemerr ShouldBeEmpty
+
   - name: pull many values with explicit limit to 2
     steps:
       - script: sed -i "s/true/false/g" ingress-descriptor.yaml
@@ -74,6 +113,21 @@ testcases:
       - script: echo '{"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}' > expected.jsonl
       - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' >> expected.jsonl
       - script: lino pull source --filter-from-file customer_filter.jsonl --limit 2 > actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldBeEmpty
+      - script: diff expected.jsonl actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldBeEmpty
+
+  - name: pull many values with explicit limit to 2 scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"active":1}' > customer_filter.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}' > expected.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' >> expected.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl --limit 2 > actual.jsonl
         assertions:
           - result.code ShouldEqual 0
           - result.systemerr ShouldBeEmpty
@@ -97,11 +151,38 @@ testcases:
           - result.code ShouldEqual 0
           - result.systemout ShouldBeEmpty
 
+  - name: pull values with reversed order not respected in scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"customer_id":2}\n{"customer_id":1}' > customer_filter.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}' >> expected.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' > expected.jsonl
+      - script: lino pull source scann --filter-from-file customer_filter.jsonl --limit 2 > actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldBeEmpty
+      - script: diff expected.jsonl actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldBeEmpty
+
   - name: pull values with aditional filter
     steps:
       - script: sed -i "s/true/false/g" ingress-descriptor.yaml
       - script: echo '{"active":1}\n{"active":0}' > customer_filter.jsonl
       - script: lino pull source --filter-from-file customer_filter.jsonl --filter store_id=2 | jq .active
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldBeEmpty
+          - |
+            result.systemout ShouldEqual "1
+            0"
+
+  - name: pull values with aditional filter scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"active":1}\n{"active":0}' > customer_filter.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl --filter store_id=2 | jq .active
         assertions:
           - result.code ShouldEqual 0
           - result.systemerr ShouldBeEmpty
@@ -124,6 +205,21 @@ testcases:
           - result.code ShouldEqual 0
           - result.systemout ShouldBeEmpty
 
+  - name: pull values with override filter scann mode
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"customer_id":1}\n{"customer_id":3}' > customer_filter.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' > expected.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' >> expected.jsonl
+      - script: lino pull source --scann --filter-from-file customer_filter.jsonl --filter customer_id=2 > actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldBeEmpty
+      - script: diff expected.jsonl actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldBeEmpty
+
   - name: pull values with filter from stdin
     steps:
       - script: sed -i "s/true/false/g" ingress-descriptor.yaml
@@ -131,6 +227,21 @@ testcases:
       - script: echo '{"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}' > expected.jsonl
       - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' >> expected.jsonl
       - script: lino pull source --filter-from-file - < customer_filter.jsonl > actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldBeEmpty
+      - script: diff expected.jsonl actual.jsonl
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldBeEmpty
+
+  - name: pull values with filter scann mode from stdin
+    steps:
+      - script: sed -i "s/true/false/g" ingress-descriptor.yaml
+      - script: echo '{"customer_id":1}\n{"customer_id":2}' > customer_filter.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":5,"create_date":"2006-02-14T00:00:00Z","customer_id":1,"email":"MARY.SMITH@sakilacustomer.org","first_name":"MARY","last_name":"SMITH","last_update":"2006-02-15T09:57:20Z","store_id":1}' > expected.jsonl
+      - script: echo '{"active":1,"activebool":true,"address_id":6,"create_date":"2006-02-14T00:00:00Z","customer_id":2,"email":"PATRICIA.JOHNSON@sakilacustomer.org","first_name":"PATRICIA","last_name":"JOHNSON","last_update":"2006-02-15T09:57:20Z","store_id":1}' >> expected.jsonl
+      - script: lino pull source --scann --filter-from-file - < customer_filter.jsonl > actual.jsonl
         assertions:
           - result.code ShouldEqual 0
           - result.systemerr ShouldBeEmpty


### PR DESCRIPTION
This patch introduces a `--scann` flag that modifies the behavior of a pull. This is particularly useful when you need to extract a significant portion of your database. Instead of filtering data during the extraction process, this mode allows you to first pull all the data and then apply the filter as a post-processing step.

This method can be faster than querying the database for each individual row with filters applied, especially when dealing with large datasets. It minimizes the need for multiple database queries and speeds up the extraction process by retrieving all the data at once, then excluding unwanted rows afterward.

### Changes Overview:
1. **CLI Update**: 
   - A new `scann` flag (`--scann`) is added to the pull command for filtering in memory.
   - The command is updated to handle both types of filtering: using filters from files and using the `scann` flag to filter in memory.

2. **Handler Changes**:
   - The handler for pulling data is updated to pass the `scann` option, which influences how the filters are applied.

3. **Driver Interface Update**:
   - The `Pull` method's signature is updated to accept an additional parameter `included KeyStore` to support filtering in memory.

4. **Test Additions**:
   - Several tests are added for the `--scann` functionality, including tests for filtering with files, applying filters, handling no matches, and ensuring order consistency.

### Summary of Key Modifications:
- **CLI**: The command now checks for the `--scann` flag and uses it to load data into memory for filtering instead of using a database filter.
- **Puller Logic**: Both `puller` and `pullerParallel` now handle the new `included KeyStore` to filter data in memory when `scann` is enabled.
- **Tests**: New tests are introduced to ensure the functionality of filtering with the `--scann` flag, including cases where there are no matches or multiple rows with specific filters.

### Example of the `--scann` Flag Use:
```bash
lino pull source --scann --filter-from-file customer_filter.jsonl
```

The flag ensures that the entire dataset is pulled and then filtered in memory based on the provided `customer_filter.jsonl` file.

