### PR TITLE
docs: Add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,14 @@ These flags allow you to specify which headers, methods, and origins are allowed
 
 Download the last binary release in your path.
 
+**macOS users** Install via Homebrew:
+
+```bash
+brew tap CGI-FR/lino
+
+brew install lino
+```
+
 ## Contributors
 
 * CGI France ✉[Contact support](mailto:LINO.fr@cgi.com)


### PR DESCRIPTION
This PR updates the installation section of the `README.md` to include instructions for installing LINO via Homebrew on macOS.

The Homebrew formula is located in the [homebrew-lino](https://github.com/CGI-FR/homebrew-lino) repository. I have personally tested the installation process locally to ensure its correctness.